### PR TITLE
Restore using the mysql binary to prevent memory errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ To specify a different local database connection:
 LOCAL_TARGET_CONNECTION=different_mysql_connection
 ```
 
+Set the mysql command path:
+
+```
+LOCAL_MYSQL_PATH=/usr/bin/mysql
+```
+
 For only mysqldump:
 ```
 REMOTE_MYSQLDUMP_SKIP_TZ_UTC=true

--- a/config/dbsync.php
+++ b/config/dbsync.php
@@ -68,4 +68,6 @@ return [
     'targetConnection' => env('LOCAL_TARGET_CONNECTION', 'mysql'),
 
     'mysqldumpSkipTzUtc' => env('REMOTE_MYSQLDUMP_SKIP_TZ_UTC', false),
+    
+    'localMysqlPath' => env('LOCAL_MYSQL_PATH', '/usr/local/bin/mysql'),
 ];


### PR DESCRIPTION
Modify the restore process, so that it uses mysql instead to prevent memory issues.

This should close #18 and simplify the restore process, along with increasing the speed of the restore.