### PR TITLE
The unused  $targetConnection is made dynamic.

### DIFF
--- a/src/Console/DbSyncCommand.php
+++ b/src/Console/DbSyncCommand.php
@@ -38,12 +38,15 @@ class DbSyncCommand extends Command
         $mysqldumpSkipTzUtc    = config('dbsync.mysqldumpSkipTzUtc') ? '--skip-tz-utc' : '';
 
         $targetConnection      = config('dbsync.targetConnection');
+        $defaultConnection     = config('database.default');
 
-        $localUsername = config('database.connections.mysql.username');
-        $localPassword = config('database.connections.mysql.password');
-        $localHostname = config('database.connections.mysql.host');
-        $localPort = config('database.connections.mysql.port');
-        $localDatabase = config('database.connections.mysql.database');
+        $defaultConnection = empty($targetConnection) ? $defaultConnection: $targetConnection;
+
+        $localUsername = config("database.connections.{$defaultConnection}.username");
+        $localPassword = config("database.connections.{$defaultConnection}.password");
+        $localHostname = config("database.connections.{$defaultConnection}.host");
+        $localPort = config("database.connections.{$defaultConnection}.port");
+        $localDatabase = config("database.connections.{$defaultConnection}.database");
         $localMysqlPath = config('dbsync.localMysqlPath');
 
         if (empty($host) || empty($username) || empty($database)) {


### PR DESCRIPTION
<img width="837" alt="Screenshot 2024-06-24 at 17 37 35" src="https://github.com/dcblogdev/laravel-db-sync/assets/1975129/7ebfc83d-c91f-4c5a-b326-db2d7c3448de">

The unused  $targetConnection is made dynamic. If you need to LOCAL_TARGET_CONNECTION, you can give the target connection another hand the connection is made default connection instead of just "mysql" connection.