### PR TITLE
Add anonymization support with `--anonymize` flag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ You can publish the config file with:
 php artisan vendor:publish --provider="Dcblogdev\DbSync\DbSyncServiceProvider" --tag="config"
 ```
 
+**Note:** If you're updating from an earlier version, republish the config to get the new anonymization options:
+
+```
+php artisan vendor:publish --provider="Dcblogdev\DbSync\DbSyncServiceProvider" --tag="config" --force
+```
+
 ## .env
 
 Set the remote database credentials in your .env file
@@ -111,12 +117,56 @@ php artisan db:production-sync --tables=users,orders,products
 
 When `--tables` is used, the `REMOTE_DATABASE_IGNORE_TABLES` list is bypassed — only the specified tables are exported.
 
+## Anonymizing Data
+
+You can anonymize sensitive data after syncing by using the `--anonymize` or `-A` flag. This is **opt-in only** and disabled by default.
+
+### Configuration
+
+First, define which tables and columns should be anonymized in `config/dbsync.php`:
+
+```php
+'anonymize' => [
+    'users' => [
+        'email' => 'safeEmail',
+        'name' => 'name',
+        'phone' => 'phoneNumber',
+        'password' => 'bcrypt:password',
+    ],
+    'customers' => [
+        'email' => 'safeEmail',
+        'first_name' => 'firstName',
+        'last_name' => 'lastName',
+        'address' => 'address',
+    ],
+],
+```
+
+The values use [Faker](https://fakerphp.github.io/) methods. Special prefix `bcrypt:` will hash the generated value.
+
+### Usage
+
+```bash
+php artisan db:production-sync --anonymize
+```
+
+Or use the shorthand:
+
+```bash
+php artisan db:production-sync -A
+```
+
+The anonymization runs **after** the database import is complete. Each configured table will be processed with a progress indicator.
+
+**Important:** Only use anonymization when syncing to local/staging environments and ensure you have permission to sync production data within your organization's policies.
+
 ## Aliases
 
 There are shortcuts that can be used:
 
 `-T` = will use `--test`
-`F` = will use `--filename`
+`-F` = will use `--filename`
+`-A` = will use `--anonymize`
 
 ## Alternative name
 

--- a/config/dbsync.php
+++ b/config/dbsync.php
@@ -74,14 +74,34 @@ return [
 
     'mysqldumpSkipTzUtc' => env('REMOTE_MYSQLDUMP_SKIP_TZ_UTC', false),
 
-
     /*
     * List all the environment variables that need to be set for the command to work
     */
     'environments' => [
         'local',
-        'staging'
+        'staging',
     ],
-    
+
     'localMysqlPath' => env('LOCAL_MYSQL_PATH', '/usr/local/bin/mysql'),
+
+    /*
+     * Anonymize table data after import (opt-in only via --anonymize flag)
+     * Define which tables and columns should be anonymized using Faker methods
+     *
+     * Example:
+     * 'anonymize' => [
+     *     'users' => [
+     *         'email' => 'safeEmail',
+     *         'name' => 'name',
+     *         'phone' => 'phoneNumber',
+     *     ],
+     * ],
+     */
+    'anonymize' => [
+        // 'users' => [
+        //     'email' => 'safeEmail',
+        //     'name' => 'name',
+        //     'password' => 'bcrypt:password',
+        // ],
+    ],
 ];

--- a/src/Console/DbSyncCommand.php
+++ b/src/Console/DbSyncCommand.php
@@ -2,11 +2,13 @@
 
 namespace Dcblogdev\DbSync\Console;
 
+use Faker\Factory as Faker;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 
 class DbSyncCommand extends Command
 {
-    protected $signature   = 'db:production-sync {--T|test} {--F|filename=} {--tables=}';
+    protected $signature   = 'db:production-sync {--T|test} {--F|filename=} {--tables=} {--A|anonymize}';
     protected $description = 'Sync production database with local';
 
     public function handle(): bool
@@ -40,11 +42,11 @@ class DbSyncCommand extends Command
 
         $defaultConnection = empty($targetConnection) ? $defaultConnection : $targetConnection;
 
-        $localUsername = config("database.connections.{$defaultConnection}.username");
-        $localPassword = config("database.connections.{$defaultConnection}.password");
-        $localHostname = config("database.connections.{$defaultConnection}.host");
-        $localPort = config("database.connections.{$defaultConnection}.port");
-        $localDatabase = config("database.connections.{$defaultConnection}.database");
+        $localUsername  = config("database.connections.{$defaultConnection}.username");
+        $localPassword  = config("database.connections.{$defaultConnection}.password");
+        $localHostname  = config("database.connections.{$defaultConnection}.host");
+        $localPort      = config("database.connections.{$defaultConnection}.port");
+        $localDatabase  = config("database.connections.{$defaultConnection}.database");
         $localMysqlPath = config('dbsync.localMysqlPath');
 
         if (empty($host) || empty($username) || empty($database)) {
@@ -54,13 +56,12 @@ class DbSyncCommand extends Command
         }
 
         if ($inTest === false) {
-
             $ignoreString = null;
 
             $tablesToDump = '';
 
             if ($this->option('tables')) {
-                $tables = explode(',', $this->option('tables'));
+                $tables       = explode(',', $this->option('tables'));
                 $tablesToDump = implode(' ', $tables);
             } else {
                 foreach ($ignoreTables as $name) {
@@ -68,12 +69,12 @@ class DbSyncCommand extends Command
                 }
             }
 
-            $useSsh && $this->info("\n" . sprintf('Connecting to %s@%s on port %s', $sshUsername, $host, $sshPort) . "\n");
+            $useSsh && $this->info("\n".sprintf('Connecting to %s@%s on port %s', $sshUsername, $host, $sshPort)."\n");
 
             if (isset($tables) && count($tables) > 0) {
-                $this->info("\n" . 'Syncing tables: ' . implode(', ', $tables) . "\n");
+                $this->info("\n".'Syncing tables: '.implode(', ', $tables)."\n");
             } else {
-                $this->info("\n" . 'Syncing database: ' . $database . "\n");
+                $this->info("\n".'Syncing database: '.$database."\n");
             }
 
             $bar = $this->output->createProgressBar(2);
@@ -113,10 +114,83 @@ class DbSyncCommand extends Command
             if ($removeFileAfterImport === true) {
                 unlink($fileName);
             }
+
+            // Anonymize data if --anonymize flag is set
+            if ($this->option('anonymize')) {
+                $this->anonymizeData($defaultConnection);
+            }
         }
 
         $this->info("\nDB Synced");
 
         return true;
+    }
+
+    protected function anonymizeData(string $connection): void
+    {
+        $anonymizationConfig = config('dbsync.anonymize');
+
+        if (empty($anonymizationConfig) || ! is_array($anonymizationConfig)) {
+            $this->warn('No anonymization configuration found. Add tables to config/dbsync.php');
+
+            return;
+        }
+
+        $this->newLine();
+        $this->info('Anonymizing data...');
+        $this->newLine();
+
+        $faker       = Faker::create();
+        $totalTables = count($anonymizationConfig);
+        $bar         = $this->output->createProgressBar($totalTables);
+        $bar->setFormat(' %current%/%max% [%bar%] %percent:3s%% -- %message%');
+        $bar->setMessage('Starting anonymization...');
+        $bar->start();
+
+        foreach ($anonymizationConfig as $table => $columns) {
+            $bar->setMessage("Anonymizing table: {$table}");
+
+            try {
+                // Get all records from the table
+                $records = DB::connection($connection)->table($table)->get();
+
+                foreach ($records as $record) {
+                    $updates = [];
+
+                    foreach ($columns as $column => $fakerMethod) {
+                        // Handle special cases like bcrypt
+                        if (str_starts_with($fakerMethod, 'bcrypt:')) {
+                            $actualMethod     = str_replace('bcrypt:', '', $fakerMethod);
+                            $updates[$column] = bcrypt($faker->$actualMethod);
+                        } else {
+                            $updates[$column] = $faker->$fakerMethod;
+                        }
+                    }
+
+                    // Use all columns as WHERE conditions to uniquely identify the record
+                    $where = [];
+                    foreach ((array) $record as $col => $val) {
+                        $where[$col] = $val;
+                    }
+
+                    // Update the record
+                    DB::connection($connection)
+                        ->table($table)
+                        ->where($where)
+                        ->limit(1)
+                        ->update($updates);
+                }
+
+                $bar->advance();
+            } catch (\Exception $e) {
+                $this->newLine();
+                $this->error("Failed to anonymize table '{$table}': ".$e->getMessage());
+                $bar->advance();
+            }
+        }
+
+        $bar->setMessage('Anonymization complete!');
+        $bar->finish();
+        $this->newLine();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,5 +36,6 @@ class TestCase extends Orchestra
             'local',
             'staging'
         ]);
+        $app['config']->set('dbsync.anonymize', []);
     }
 }

--- a/tests/Unit/DbSyncTest.php
+++ b/tests/Unit/DbSyncTest.php
@@ -35,3 +35,19 @@ test('runs with valid credentials', function () {
         ->assertExitCode(true)
         ->expectsOutput("\nDB Synced");
 });
+
+test('anonymize flag accepts configuration', function () {
+    config(['app.env' => 'local']);
+    config(['dbsync.host' => '127.0.0.1']);
+    config(['dbsync.username' => 'root']);
+    config(['dbsync.database' => 'demo']);
+    config(['dbsync.anonymize' => [
+        'users' => [
+            'email' => 'safeEmail',
+            'name' => 'name',
+        ],
+    ]]);
+
+    $this->artisan('db:production-sync --test --anonymize')
+        ->assertExitCode(true);
+});


### PR DESCRIPTION
1. Configuration (config/dbsync.php)
Added anonymize config array with examples showing how to map tables and columns to Faker methods
Supports special syntax like bcrypt:password for hashed passwords

2. Command Flag (src/Console/DbSyncCommand.php)
Added --anonymize (or -A) flag to the command signature
Feature is off by default (opt-in only)

3. Anonymization Logic (src/Console/DbSyncCommand.php)
New anonymizeData() method processes configured tables after import
Uses Laravel's Faker library for realistic fake data
Progress bar shows which table is being anonymized
Error handling for each table (continues if one fails)
Updates records individually to ensure proper data generation

Usage Example
``` php
// In config/dbsync.php
'anonymize' => [
    'users' => [
        'email' => 'safeEmail',
        'name' => 'name',
        'phone' => 'phoneNumber',
        'password' => 'bcrypt:password',
    ],
    'customers' => [
        'email' => 'safeEmail',
        'first_name' => 'firstName',
        'last_name' => 'lastName',
    ],
],
```

``` bash
# Sync with anonymization
php artisan db:production-sync --anonymize

# Or use shorthand
php artisan db:production-sync -A
```
