### PR TITLE
Add support for MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ For only mysqldump:
 REMOTE_MYSQLDUMP_SKIP_TZ_UTC=true
 ```
 
+If the remote database uses MariaDB:
+```
+REMOTE_DATABASE_TYPE=mariadb
+```
+
 ## Usage
 
 To export a remote database to OVERRIDE your local database by running:

--- a/config/dbsync.php
+++ b/config/dbsync.php
@@ -28,6 +28,11 @@ return [
     'username' => env('REMOTE_DATABASE_USERNAME', ''),
 
     /*
+     * Set the database type
+     */
+    'databaseType' => env('REMOTE_DATABASE_TYPE', 'mysql'),
+
+    /*
      * Database host (optional)
      */
     'mysqlHostName' => env('REMOTE_DATABASE_MYSQL_HOSTNAME', 'localhost'),

--- a/src/Console/DbSyncCommand.php
+++ b/src/Console/DbSyncCommand.php
@@ -73,12 +73,12 @@ class DbSyncCommand extends Command
                 }
             }
 
-            $useSsh && $this->info("\n" . sprintf('Connecting to %s@%s on port %s', $sshUsername, $host, $sshPort) . "\n");
+            $useSsh && $this->info("\n".sprintf('Connecting to %s@%s on port %s', $sshUsername, $host, $sshPort)."\n");
 
             if (isset($tables) && count($tables) > 0) {
-                $this->info("\n" . 'Syncing tables: ' . implode(', ', $tables) . "\n");
+                $this->info("\n".'Syncing tables: '.implode(', ', $tables)."\n");
             } else {
-                $this->info("\n" . 'Syncing database: ' . $database . "\n");
+                $this->info("\n".'Syncing database: '.$database."\n");
             }
 
             $bar = $this->output->createProgressBar(2);
@@ -94,7 +94,6 @@ class DbSyncCommand extends Command
                 exec("$dumpProgram --defaults-extra-file=$remoteCnf --single-transaction $gtidPurgedOff --port=$port --host=$mysqlHostName --user=$username $database $tablesToDump $ignoreString $mysqldumpSkipTzUtc --column-statistics=0 > $fileName", $output);
                 unlink($remoteCnf);
             }
-            error_log(print_r($dumpProgram, true));
 
             $bar->setMessage('Importing...');
             $bar->advance();
@@ -189,7 +188,7 @@ class DbSyncCommand extends Command
                 $bar->advance();
             } catch (\Exception $e) {
                 $this->newLine();
-                $this->error("Failed to anonymize table '{$table}': " . $e->getMessage());
+                $this->error("Failed to anonymize table '{$table}': ".$e->getMessage());
                 $bar->advance();
             }
         }

--- a/src/Console/DbSyncCommand.php
+++ b/src/Console/DbSyncCommand.php
@@ -26,6 +26,7 @@ class DbSyncCommand extends Command
         $sshPort     = config('dbsync.sshPort');
         $host        = config('dbsync.host');
 
+        $databaseType          = config('dbsync.databaseType');
         $mysqlHostName         = config('dbsync.mysqlHostName');
         $username              = config('dbsync.username');
         $database              = config('dbsync.database');
@@ -36,6 +37,9 @@ class DbSyncCommand extends Command
         $removeFileAfterImport = config('dbsync.removeFileAfterImport');
         $fileName              = $this->option('filename') ?? config('dbsync.defaultFileName');
         $mysqldumpSkipTzUtc    = config('dbsync.mysqldumpSkipTzUtc') ? '--skip-tz-utc' : '';
+        $gtidPurgedOff         = $databaseType === 'mysql' ? '--set-gtid-purged=OFF' : '';
+
+        $dumpProgram           = $databaseType === 'mysql' ? 'mysqldump' : 'mariadb-dump';
 
         $targetConnection      = config('dbsync.targetConnection');
         $defaultConnection     = config('database.default');
@@ -69,12 +73,12 @@ class DbSyncCommand extends Command
                 }
             }
 
-            $useSsh && $this->info("\n".sprintf('Connecting to %s@%s on port %s', $sshUsername, $host, $sshPort)."\n");
+            $useSsh && $this->info("\n" . sprintf('Connecting to %s@%s on port %s', $sshUsername, $host, $sshPort) . "\n");
 
             if (isset($tables) && count($tables) > 0) {
-                $this->info("\n".'Syncing tables: '.implode(', ', $tables)."\n");
+                $this->info("\n" . 'Syncing tables: ' . implode(', ', $tables) . "\n");
             } else {
-                $this->info("\n".'Syncing database: '.$database."\n");
+                $this->info("\n" . 'Syncing database: ' . $database . "\n");
             }
 
             $bar = $this->output->createProgressBar(2);
@@ -83,13 +87,14 @@ class DbSyncCommand extends Command
             $bar->start();
 
             if ($useSsh === true) {
-                exec("ssh $sshUsername@$host -p$sshPort \"mysqldump --single-transaction --set-gtid-purged=OFF --port=$port --host=$mysqlHostName --user=$username --password=$password $database $tablesToDump $ignoreString 2>/dev/null\" > $fileName", $output);
+                exec("ssh $sshUsername@$host -p$sshPort \"$dumpProgram --single-transaction $gtidPurgedOff --port=$port --host=$mysqlHostName --user=$username --password=$password $database $tablesToDump $ignoreString 2>/dev/null\" > $fileName", $output);
             } else {
                 $remoteCnf = tempnam(sys_get_temp_dir(), 'dbsync_');
                 file_put_contents($remoteCnf, "[client]\npassword={$password}\n");
-                exec("mysqldump --defaults-extra-file=$remoteCnf --single-transaction --set-gtid-purged=OFF --port=$port --host=$mysqlHostName --user=$username $database $tablesToDump $ignoreString $mysqldumpSkipTzUtc --column-statistics=0 > $fileName", $output);
+                exec("$dumpProgram --defaults-extra-file=$remoteCnf --single-transaction $gtidPurgedOff --port=$port --host=$mysqlHostName --user=$username $database $tablesToDump $ignoreString $mysqldumpSkipTzUtc --column-statistics=0 > $fileName", $output);
                 unlink($remoteCnf);
             }
+            error_log(print_r($dumpProgram, true));
 
             $bar->setMessage('Importing...');
             $bar->advance();
@@ -184,7 +189,7 @@ class DbSyncCommand extends Command
                 $bar->advance();
             } catch (\Exception $e) {
                 $this->newLine();
-                $this->error("Failed to anonymize table '{$table}': ".$e->getMessage());
+                $this->error("Failed to anonymize table '{$table}': " . $e->getMessage());
                 $bar->advance();
             }
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,6 +21,7 @@ class TestCase extends Orchestra
         $app['config']->set('dbsync.sshUsername', '');
         $app['config']->set('dbsync.sshPort', 22);
         $app['config']->set('dbsync.username', '');
+        $app['config']->set('dbsync.databaseType', 'mysql');
         $app['config']->set('dbsync.mysqlHostName', 'localhost');
         $app['config']->set('dbsync.port', 3306);
         $app['config']->set('dbsync.database', '');


### PR DESCRIPTION
This PR allows this package to work with MariaDB.
In MariaDB, `--set-gtid-purged` on `mysqldump` does not exist and throws an error.

Here is the changes I made:
- Added `REMOTE_DATABASE_TYPE` config variable, with the default value to `mysql`, so there is no breaking change
- If `REMOTE_DATABASE_TYPE` is set to `mysql`, `--set-gtid-purged=OFF` is used, otherwise it is not
- If `REMOTE_DATABASE_TYPE` is set to `mysql`, `mysqldump` is used, otherwise `mariadb-dump` is used

There's some observation/question where you maybe can help:
- The existing config variable `REMOTE_DATABASE_MYSQL_HOSTNAME` use mysql in its name, which could be confusing now that MariaDB is supported, not a big deal and changing it would be a breaking change. A solution could be to have a new `REMOTE_DATABASE_HOSTNAME` (without mysql) variable, and throw a deprecation notice when the old one is used.
- `REMOTE_DATABASE_TYPE` is not strict, only `mysql` uses `--set-gtid-purged=OFF`, any other string is not using it. So using `mariadb` would have the same effect as `foobar`.
- No error is shown if the dump fails, but that's probably out of this scope.
- `mysqldump` is still available with MariaDB, but deprecated, `mariadb-dump` is replacing it.
- I didn't add tests.

Closes #30 